### PR TITLE
Fix GenServer.call/3 timeout

### DIFF
--- a/lib/double.ex
+++ b/lib/double.ex
@@ -146,18 +146,18 @@ defmodule Double do
   def clear(dbl, function_name \\ nil) do
     double_id = if is_atom(dbl), do: Atom.to_string(dbl), else: dbl._double_id
     pid = Registry.whereis_double(double_id)
-    GenServer.call(pid, {:clear, dbl, function_name})
+    GenServer.call(pid, {:clear, dbl, function_name}, :infinity)
   end
 
   @doc false
   def func_list(pid) do
-    GenServer.call(pid, :func_list)
+    GenServer.call(pid, :func_list, :infinity)
   end
 
   defp do_allow(dbl, function_name, func) do
     double_id = if is_atom(dbl), do: Atom.to_string(dbl), else: dbl._double_id
     pid = Registry.whereis_double(double_id)
-    GenServer.call(pid, {:allow, dbl, function_name, func})
+    GenServer.call(pid, {:allow, dbl, function_name, func}, :infinity)
   end
 
   defp verify_mod_double(dbl, function_name, func) when is_atom(dbl) do

--- a/lib/double/eval.ex
+++ b/lib/double/eval.ex
@@ -12,7 +12,7 @@ defmodule Double.Eval do
   end
 
   def eval(code) do
-    GenServer.call(__MODULE__, {:eval, code})
+    GenServer.call(__MODULE__, {:eval, code}, :infinity)
   end
 
   def init(initial) do

--- a/lib/double/func_list.ex
+++ b/lib/double/func_list.ex
@@ -11,7 +11,7 @@ defmodule Double.FuncList do
   end
 
   def push(pid, function_name, func) when is_function(func) and is_atom(function_name) do
-    GenServer.call(pid, {:push, function_name, func})
+    GenServer.call(pid, {:push, function_name, func}, :infinity)
   end
 
   def clear(_pid, _function_name \\ nil)
@@ -23,11 +23,11 @@ defmodule Double.FuncList do
   end
 
   def clear(pid, function_name) do
-    GenServer.call(pid, {:clear, function_name})
+    GenServer.call(pid, {:clear, function_name}, :infinity)
   end
 
   def apply(pid, function_name, args) when is_atom(function_name) and is_list(args) do
-    state = GenServer.call(pid, :state)
+    state = GenServer.call(pid, :state, :infinity)
 
     funcs =
       state.funcs
@@ -52,7 +52,7 @@ defmodule Double.FuncList do
           end
 
         {:ok, return_value, found} ->
-          GenServer.call(pid, {:mark_applied, found})
+          GenServer.call(pid, {:mark_applied, found}, :infinity)
           return_value
       end
 
@@ -60,11 +60,11 @@ defmodule Double.FuncList do
   end
 
   def list(pid) do
-    GenServer.call(pid, :list)
+    GenServer.call(pid, :list, :infinity)
   end
 
   def state(pid) do
-    GenServer.call(pid, :state)
+    GenServer.call(pid, :state, :infinity)
   end
 
   # SERVER

--- a/lib/double/registry.ex
+++ b/lib/double/registry.ex
@@ -14,24 +14,24 @@ defmodule Double.Registry do
   end
 
   def whereis_double(double_id) do
-    GenServer.call(:registry, {:whereis_double, double_id})
+    GenServer.call(:registry, {:whereis_double, double_id}, :infinity)
   end
 
   def whereis_test(double_id) do
-    GenServer.call(:registry, {:whereis_test, double_id})
+    GenServer.call(:registry, {:whereis_test, double_id}, :infinity)
   end
 
   def source_for(double_id) do
-    GenServer.call(:registry, {:source_for, double_id})
+    GenServer.call(:registry, {:source_for, double_id}, :infinity)
   end
 
   def opts_for(double_id) do
-    GenServer.call(:registry, {:opts_for, double_id})
+    GenServer.call(:registry, {:opts_for, double_id}, :infinity)
   end
 
   def register_double(double_id, pid, test_pid, source, opts) do
     arg = {:register_id, double_id, pid, test_pid, source, opts}
-    GenServer.call(:registry, arg)
+    GenServer.call(:registry, arg, :infinity)
   end
 
   # SERVER


### PR DESCRIPTION
In some cases, slow or CPU intensive tests may cause `GenServer.call/3`
to time out and exit with `** (EXIT) time out`. The default timeout
value for `GenServer.call/3` is 5 seconds. Override the default value at
set it as `:infinity`.

Tests have their own timeout values, so timeouts for very long tests
should still be triggered.

I also created a PR against the upstream library.